### PR TITLE
Translate naive-approch-write.md

### DIFF
--- a/microbit/src/07-uart/naive-approch-write.md
+++ b/microbit/src/07-uart/naive-approch-write.md
@@ -1,8 +1,14 @@
-# Naive approach and `write!`
+<!-- # Naive approach and `write!`  -->
 
-## Naive approach
+# イテレータを使う方法と`write!`
 
-You probably came up with a program similar to the following:
+<!-- ## Naive approach -->
+
+## イテレータを使う方法
+
+<!-- You probably came up with a program similar to the following: -->
+
+おそらく次のようなプログラムを書かれたことと思います。
 
 ```rs
 #![no_main]
@@ -66,15 +72,22 @@ fn main() -> ! {
 }
 ```
 
-While this is a perfectly valid implementation, at some point
+<!-- While this is a perfectly valid implementation, at some point
 you might want to have all the nice perks of `print!` such
-as argument formatting and so on. If you are wondering how to do that, read on.
+as argument formatting and so on. If you are wondering how to do that, read on. -->
 
-## `write!` and `core::fmt::Write`
-The `core::fmt::Write` trait allows us to use any struct that implements
+これも立派な実装ですが、別の方法がいいかもしれません。`print!`でするように、文字列をそのまま引数として渡すやり方です。ではどうやってそうするのか。読み進めてください。
+
+<!-- ## `write!` and `core::fmt::Write` -->
+
+## `write!`と`core::fmt::Write`
+
+<!-- The `core::fmt::Write` trait allows us to use any struct that implements
 it in basically the same way as we use `print!` in the `std` world.
 In this case, the `Uart` struct from the `nrf` HAL does implement `core::fmt::Write`
-so we can refactor our previous program into this:
+so we can refactor our previous program into this: -->
+
+`core::fmt::Write`というトレイトがあります。このトレイトを実装した構造体は、フォーマットされた文字列の出力先として扱うことができ、`std`環境における`print!`と同じような処理を可能にします。ここでは、`nrf` HALの`Uart`構造体が`core::fmt::Write`を実装しています。これを利用して先ほどのプログラムをリファクタリングすると、こうなります：
 
 ```rs
 #![no_main]
@@ -137,6 +150,8 @@ fn main() -> ! {
 }
 ```
 
-If you were to flash this program onto your micro:bit, you'll
+<!-- If you were to flash this program onto your micro:bit, you'll
 see that it is functionally equivalent to the iterator-based
-program you came up with.
+program you came up with. -->
+
+このプログラムをmicro:bitに書き込むと、イテレータを使ったプログラムと同じ結果を得ることができます。

--- a/microbit/src/07-uart/naive-approch-write.md
+++ b/microbit/src/07-uart/naive-approch-write.md
@@ -76,7 +76,7 @@ fn main() -> ! {
 you might want to have all the nice perks of `print!` such
 as argument formatting and so on. If you are wondering how to do that, read on. -->
 
-このイテレータを使った実装も正解ですが、別の方法がいいかもしれません。`print!`でするように、文字列をそのまま引数として渡すやり方です。ではどうやってそうするのか。読み進めてください。
+これも立派な実装ですが、`print!`のように引数を文字列にフォーマットできたらいいのに、とは思いませんか？　そんなことができるのでしょうか。読み進めてください。
 
 <!-- ## `write!` and `core::fmt::Write` -->
 
@@ -154,4 +154,4 @@ fn main() -> ! {
 see that it is functionally equivalent to the iterator-based
 program you came up with. -->
 
-このプログラムをmicro:bitに書き込むと、イテレータを使ったプログラムと同じ結果を得ることができます。
+このプログラムをmicro:bitに書き込むと、リファクタリング前のイテレータを使ったプログラムと同じ結果を得ることができます。

--- a/microbit/src/07-uart/naive-approch-write.md
+++ b/microbit/src/07-uart/naive-approch-write.md
@@ -1,10 +1,10 @@
 <!-- # Naive approach and `write!`  -->
 
-# イテレータを使う方法と`write!`
+# 単純な方法と`write!`
 
 <!-- ## Naive approach -->
 
-## イテレータを使う方法
+## 単純な方法
 
 <!-- You probably came up with a program similar to the following: -->
 
@@ -76,7 +76,7 @@ fn main() -> ! {
 you might want to have all the nice perks of `print!` such
 as argument formatting and so on. If you are wondering how to do that, read on. -->
 
-これも立派な実装ですが、別の方法がいいかもしれません。`print!`でするように、文字列をそのまま引数として渡すやり方です。ではどうやってそうするのか。読み進めてください。
+このイテレータを使った実装も正解ですが、別の方法がいいかもしれません。`print!`でするように、文字列をそのまま引数として渡すやり方です。ではどうやってそうするのか。読み進めてください。
 
 <!-- ## `write!` and `core::fmt::Write` -->
 


### PR DESCRIPTION
今日の翻訳です。これは原文がかなり雑な印象です。適当に表現を変えました。間違っているところあればご指摘ください。

"Naive"は「未熟な」とか「うぶな」とかになるのでしょうが、ここでは「未熟さ」を指摘するよりも「イテレータ/ write!」の対比を示したほうがよいのではないかと判断しました。また「イテレータ」に言及しておかないと最後の一文でイテレータが出てきたときに唐突感があるとも考えました。
"Naive"を訳す場合は、「（うぶ・未熟・真っ正直・こなれない）な方法とwrite!」などにして、７９行目を「このイテレータを使った実装も正解ですが、別の方法がいいかもしれません。」とするのがいいかもしれません。

どう思われますか？